### PR TITLE
chore: Apply is_free migration to production (cr-3isea)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Applied migration 005_add_is_free_column.sql to production database
+  - Added `is_free` boolean column to episodes table (default: FALSE)
+  - Created partial index `idx_episodes_is_free` for efficient free episode queries
+
 ### Added
 - Automatic version bump system with commit message conventions
 - VERSIONING.md documenting version bump policy


### PR DESCRIPTION
## Summary
- Applied migration `005_add_is_free_column.sql` to production PostgreSQL database
- Added `is_free` BOOLEAN column to episodes table with DEFAULT FALSE
- Created partial index `idx_episodes_is_free` for efficient free episode queries

## Verification
Confirmed via Python script:
- Column exists with correct type (boolean) and default (false)
- Index `idx_episodes_is_free` created successfully
- Existing episodes have `is_free=False` as expected

## Test plan
- [x] Verified column exists in production database
- [x] Verified index was created
- [x] Verified existing data unaffected (default FALSE applied)

Unblocks: cr-0hiiz (Mark free episodes with is_free flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)