### PR TITLE
feat: Add is_free field to speaker search endpoint (cr-4v9eo)

### DIFF
--- a/app/api/transcript_routes.py
+++ b/app/api/transcript_routes.py
@@ -529,6 +529,7 @@ def search_by_speaker():
                     e.patreon_id,
                     e.published_at,
                     e.youtube_url,
+                    e.is_free,
                     (
                         SELECT string_agg(ts2.word, ' ' ORDER BY ts2.segment_index)
                         FROM transcript_segments ts2
@@ -558,6 +559,7 @@ def search_by_speaker():
                     e.patreon_id,
                     e.published_at,
                     e.youtube_url,
+                    e.is_free,
                     (
                         SELECT string_agg(ts2.word, ' ' ORDER BY ts2.segment_index)
                         FROM transcript_segments ts2
@@ -586,6 +588,7 @@ def search_by_speaker():
                 "patreon_id": row["patreon_id"],
                 "published_at": row["published_at"].isoformat() if row["published_at"] else None,
                 "youtube_url": row["youtube_url"],
+                "is_free": row["is_free"],
                 "context": row["context"]
             })
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -114,6 +114,7 @@ def test_search_by_speaker_with_params(client):
             "patreon_id": "123",
             "published_at": None,
             "youtube_url": None,
+            "is_free": True,
             "context": "this is a test context"
         }
     ]


### PR DESCRIPTION
## Summary
- Adds missing `is_free` field to the `/api/transcripts/search/speaker` endpoint
- Updates test mock data to include the new field
- Ensures consistent API response format across all transcript search routes

## Context
The `search_by_speaker` endpoint was missing the `is_free` field that other search endpoints (`search_single_word`, `search_phrase`, `on_this_day`) already return. This makes the API consistent for the YouTube embed pipeline.

## Test plan
- [x] Run unit tests: `pytest tests/unit/test_api.py` - all 16 tests pass
- [ ] Verify `/api/transcripts/search/speaker` returns `is_free` field after deployment
- [ ] Restart Flask server after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)