### PR TITLE
feat: Match episodes to YouTube videos (cr-2z3s1)

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -37,15 +37,48 @@ def process(args):
         print(f"  Failed: {results['processed']['failed']}")
 
 
+def youtube_fetch(args):
+    """Fetch YouTube videos and save to JSON."""
+    from app.youtube.client import fetch_and_save_videos
+
+    output_path = args.output or "app/data/youtube_videos.json"
+    use_api = not args.rss_only
+
+    print(f"Fetching YouTube videos (use_api={use_api}, max={args.max})...")
+    videos = fetch_and_save_videos(
+        output_path=output_path,
+        use_api=use_api,
+        max_results=args.max,
+    )
+    print(f"  Saved {len(videos)} videos to {output_path}")
+
+
 def youtube_sync(args):
     """Sync YouTube URLs for episodes."""
+    import os
     from app.db.repository import EpisodeRepository
-    from app.youtube.client import YouTubeClient, match_episode_to_video
+    from app.youtube.client import (
+        YouTubeClient,
+        match_episode_to_video_detailed,
+        load_videos_from_json,
+        is_free_monday_episode,
+    )
 
-    print("Fetching YouTube videos...")
-    yt_client = YouTubeClient()
-    videos = yt_client.get_videos(max_results=100)
-    print(f"  Found {len(videos)} videos")
+    # Load videos from JSON file or fetch fresh
+    json_path = args.json or "app/data/youtube_videos.json"
+
+    if args.fetch or not os.path.exists(json_path):
+        print("Fetching YouTube videos...")
+        yt_client = YouTubeClient()
+        if yt_client.api_key:
+            videos = yt_client.get_videos_with_duration(max_results=500)
+        else:
+            videos = yt_client.get_videos(max_results=100)
+        print(f"  Fetched {len(videos)} videos")
+    else:
+        print(f"Loading YouTube videos from {json_path}...")
+        videos = load_videos_from_json(json_path)
+        print(f"  Loaded {len(videos)} videos")
 
     repo = EpisodeRepository()
 
@@ -57,26 +90,62 @@ def youtube_sync(args):
     print(f"Matching {len(episodes)} episodes...")
 
     matched = 0
+    ambiguous = 0
+    ambiguous_matches = []
+
     for episode in episodes:
-        video = match_episode_to_video(
+        result = match_episode_to_video_detailed(
             episode.title,
             episode.published_at,
             videos,
             date_tolerance_days=args.tolerance,
         )
-        if video:
+
+        if result.video:
+            is_free = is_free_monday_episode(result.video)
+            status_prefix = "[AMBIGUOUS] " if result.is_ambiguous else ""
+
+            if result.is_ambiguous:
+                ambiguous += 1
+                ambiguous_matches.append({
+                    "episode": episode,
+                    "result": result,
+                })
+
             if args.dry_run:
-                print(f"  [DRY RUN] Would match: {episode.title[:50]}... -> {video.title[:50]}...")
+                print(f"  {status_prefix}[DRY RUN] Would match (score={result.score}): {episode.title[:40]}...")
+                print(f"    -> {result.video.title[:50]}...")
+                if result.is_ambiguous and result.runner_up:
+                    print(f"    Runner-up (score={result.runner_up_score}): {result.runner_up.title[:50]}...")
             else:
-                repo.update_youtube_url(episode.id, video.url)
-                print(f"  Matched: {episode.title[:50]}... -> {video.url}")
+                repo.update_free_status(episode.id, result.video.url, is_free)
+                print(f"  {status_prefix}Matched (score={result.score}): {episode.title[:40]}...")
+                print(f"    -> {result.video.url}")
+                if result.is_ambiguous and result.runner_up:
+                    print(f"    Runner-up (score={result.runner_up_score}): {result.runner_up.title[:50]}...")
             matched += 1
 
     print(f"\nResults:")
     print(f"  Episodes checked: {len(episodes)}")
     print(f"  Matched: {matched}")
+    print(f"  Ambiguous (needs review): {ambiguous}")
     if args.dry_run:
         print("  (Dry run - no changes made)")
+
+    # Print ambiguous matches summary for manual review
+    if ambiguous_matches and args.verbose:
+        print(f"\n=== Ambiguous Matches (Manual Review Required) ===")
+        for item in ambiguous_matches:
+            ep = item["episode"]
+            res = item["result"]
+            print(f"\nEpisode: {ep.title}")
+            print(f"  Published: {ep.published_at}")
+            print(f"  Match 1 (score={res.score}): {res.video.title}")
+            print(f"    URL: {res.video.url}")
+            print(f"    Reasons: {', '.join(res.match_reasons)}")
+            if res.runner_up:
+                print(f"  Match 2 (score={res.runner_up_score}): {res.runner_up.title}")
+                print(f"    URL: {res.runner_up.url}")
 
 def main():
     parser = argparse.ArgumentParser(description="Crankiac management CLI")
@@ -95,11 +164,20 @@ def main():
     process_parser.add_argument("--model", default="base", help="Whisper model (tiny/base/small/medium/large)")
     process_parser.add_argument("--no-cleanup", action="store_true", help="Keep audio files after transcription")
 
+    # youtube-fetch command
+    fetch_parser = subparsers.add_parser("youtube-fetch", help="Fetch YouTube videos and save to JSON")
+    fetch_parser.add_argument("--output", "-o", help="Output JSON file path (default: app/data/youtube_videos.json)")
+    fetch_parser.add_argument("--max", type=int, default=500, help="Max videos to fetch (default: 500)")
+    fetch_parser.add_argument("--rss-only", action="store_true", help="Use RSS feed only (no API key needed, ~15 videos)")
+
     # youtube-sync command
     yt_parser = subparsers.add_parser("youtube-sync", help="Sync YouTube URLs for free episodes")
     yt_parser.add_argument("--all", action="store_true", help="Re-match all episodes (not just those without YouTube URLs)")
     yt_parser.add_argument("--dry-run", action="store_true", help="Show matches without updating database")
     yt_parser.add_argument("--tolerance", type=int, default=7, help="Date tolerance in days for matching (default: 7)")
+    yt_parser.add_argument("--json", help="Path to YouTube videos JSON file (default: app/data/youtube_videos.json)")
+    yt_parser.add_argument("--fetch", action="store_true", help="Fetch fresh videos instead of using JSON file")
+    yt_parser.add_argument("--verbose", "-v", action="store_true", help="Show detailed ambiguous match info for manual review")
 
     args = parser.parse_args()
 
@@ -107,6 +185,8 @@ def main():
         migrate()
     elif args.command == "process":
         process(args)
+    elif args.command == "youtube-fetch":
+        youtube_fetch(args)
     elif args.command == "youtube-sync":
         youtube_sync(args)
     else:


### PR DESCRIPTION
## Summary
- Add `MatchResult` dataclass for tracking match confidence, reasons, and ambiguity
- Add `match_episode_to_video_detailed()` function that identifies ambiguous matches (runner-up score within 10 points)
- Add `youtube-fetch` CLI command to fetch and save YouTube videos to JSON
- Update `youtube-sync` to load from pre-fetched JSON, update `is_free` flag, and report ambiguous matches for manual review

## Matching Strategy
1. Extract episode number from title (e.g., '867 - Title' → 867)
2. Match by episode number in YouTube title (+50 points)
3. Fallback: fuzzy title word matching (+10 per word) + date proximity (up to +20)
4. Matches with close runner-up scores flagged as ambiguous for manual review

## Test plan
- [x] All 213 tests pass
- [x] `youtube-fetch --help` works
- [x] `youtube-sync --help` works
- [x] New tests for `MatchResult` and ambiguous detection pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)