### PR TITLE
feat: Add youtube_id column to episodes table (cr-37v5g)

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -12,6 +12,7 @@ class Episode:
     published_at: Optional[datetime] = None
     duration_seconds: Optional[int] = None
     youtube_url: Optional[str] = None
+    youtube_id: Optional[str] = None
     is_free: bool = False
     processed: bool = False
     created_at: Optional[datetime] = None

--- a/db/migrations/008_add_youtube_id.sql
+++ b/db/migrations/008_add_youtube_id.sql
@@ -1,0 +1,5 @@
+-- Add youtube_id column to episodes for storing YouTube video IDs
+ALTER TABLE episodes ADD COLUMN IF NOT EXISTS youtube_id VARCHAR(20);
+
+-- Partial index on non-null youtube_id values for efficient lookups
+CREATE INDEX IF NOT EXISTS idx_episodes_youtube_id ON episodes(youtube_id) WHERE youtube_id IS NOT NULL;


### PR DESCRIPTION
Adds youtube_id column for YouTube embed support.

## Changes
- Migration: db/migrations/002_add_youtube_id.sql
- Added youtube_id VARCHAR(20) with partial index
- Updated Episode dataclass in models.py

🤖 Generated with Claude Code