### PR TITLE
feat: Update search API to return YouTube embed URL (cr-zzd0r)

### DIFF
--- a/app/api/transcript_routes.py
+++ b/app/api/transcript_routes.py
@@ -142,6 +142,7 @@ def search_single_word(word: str, limit: int, offset: int, filters: dict = None)
                 e.patreon_id,
                 e.published_at,
                 e.youtube_url,
+                e.youtube_id,
                 e.is_free,
                 (
                     SELECT string_agg(ts2.word, ' ' ORDER BY ts2.segment_index)
@@ -159,7 +160,7 @@ def search_single_word(word: str, limit: int, offset: int, filters: dict = None)
 
         results = []
         for row in cursor.fetchall():
-            results.append({
+            result = {
                 "word": row["word"],
                 "start_time": float(row["start_time"]),
                 "end_time": float(row["end_time"]),
@@ -172,7 +173,11 @@ def search_single_word(word: str, limit: int, offset: int, filters: dict = None)
                 "youtube_url": row["youtube_url"],
                 "is_free": row["is_free"],
                 "context": row["context"]
-            })
+            }
+            if row["youtube_id"]:
+                start_seconds = int(row["start_time"])
+                result["youtube_embed_url"] = f"https://www.youtube.com/embed/{row['youtube_id']}?start={start_seconds}"
+            results.append(result)
 
         return results, total
 
@@ -205,6 +210,7 @@ def search_phrase(words: list[str], limit: int, offset: int, filters: dict = Non
                     e.patreon_id,
                     e.published_at,
                     e.youtube_url,
+                    e.youtube_id,
                     e.is_free
                 FROM transcript_segments ts
                 JOIN episodes e ON ts.episode_id = e.id
@@ -243,7 +249,7 @@ def search_phrase(words: list[str], limit: int, offset: int, filters: dict = Non
 
         results = []
         for row in cursor.fetchall():
-            results.append({
+            result = {
                 "phrase": row["matched_phrase"],
                 "start_time": float(row["start_time"]),
                 "end_time": float(row["end_time"]) if row["end_time"] else None,
@@ -255,7 +261,11 @@ def search_phrase(words: list[str], limit: int, offset: int, filters: dict = Non
                 "youtube_url": row["youtube_url"],
                 "is_free": row["is_free"],
                 "context": row["context"]
-            })
+            }
+            if row["youtube_id"]:
+                start_seconds = int(row["start_time"])
+                result["youtube_embed_url"] = f"https://www.youtube.com/embed/{row['youtube_id']}?start={start_seconds}"
+            results.append(result)
 
         # Get approximate total (expensive for phrases, so estimate)
         total = len(results) if len(results) < limit else limit * 2

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -188,6 +188,7 @@ def test_search_with_date_filter(client):
             "patreon_id": "123",
             "published_at": datetime(2023, 6, 15),
             "youtube_url": "https://youtube.com/watch?v=123",
+            "youtube_id": "123",
             "is_free": True,
             "context": "this is a test context"
         }
@@ -225,6 +226,7 @@ def test_search_with_episode_number_filter(client):
             "patreon_id": "123",
             "published_at": datetime(2023, 6, 15),
             "youtube_url": None,
+            "youtube_id": None,
             "is_free": False,
             "context": "this is a test context"
         }
@@ -261,6 +263,7 @@ def test_search_with_content_type_free(client):
             "patreon_id": "123",
             "published_at": datetime(2023, 6, 15),
             "youtube_url": "https://youtube.com/watch?v=123",
+            "youtube_id": "123",
             "is_free": True,
             "context": "this is a test context"
         }
@@ -280,6 +283,9 @@ def test_search_with_content_type_free(client):
         assert "filters" in data
         assert data["filters"]["content_type"] == "free"
         assert data["results"][0]["is_free"] is True
+        # Verify youtube_embed_url is included when youtube_id is present
+        assert "youtube_embed_url" in data["results"][0]
+        assert data["results"][0]["youtube_embed_url"] == "https://www.youtube.com/embed/123?start=1"
 
 
 @pytest.mark.unit
@@ -298,6 +304,7 @@ def test_search_with_content_type_premium(client):
             "patreon_id": "123",
             "published_at": datetime(2023, 6, 15),
             "youtube_url": None,
+            "youtube_id": None,
             "is_free": False,
             "context": "this is a test context"
         }
@@ -317,6 +324,8 @@ def test_search_with_content_type_premium(client):
         assert "filters" in data
         assert data["filters"]["content_type"] == "premium"
         assert data["results"][0]["is_free"] is False
+        # Verify youtube_embed_url is NOT included when youtube_id is None
+        assert "youtube_embed_url" not in data["results"][0]
 
 
 @pytest.mark.unit
@@ -335,6 +344,7 @@ def test_search_with_multiple_filters(client):
             "patreon_id": "123",
             "published_at": datetime(2023, 6, 15),
             "youtube_url": "https://youtube.com/watch?v=123",
+            "youtube_id": "123",
             "is_free": True,
             "context": "this is a test context"
         }
@@ -374,6 +384,7 @@ def test_search_with_invalid_content_type_defaults_to_all(client):
             "patreon_id": "123",
             "published_at": datetime(2023, 6, 15),
             "youtube_url": None,
+            "youtube_id": None,
             "is_free": False,
             "context": "this is a test context"
         }


### PR DESCRIPTION
Updates search API to include YouTube embed URLs in results.

## Changes
- Added youtube_id to SELECT queries in search_single_word() and search_phrase()
- Returns youtube_url for results with youtube_id
- Format: https://www.youtube.com/embed/{youtube_id}?start={timestamp}

🤖 Generated with Claude Code