### PR TITLE
fix: Handle ValueError in list_episodes limit/offset parameters

### DIFF
--- a/app/api/transcript_routes.py
+++ b/app/api/transcript_routes.py
@@ -328,8 +328,11 @@ def get_extended_context():
 @transcript_api.route("/episodes")
 def list_episodes():
     """List all episodes with transcript status."""
-    limit = min(int(request.args.get("limit", 50)), 200)
-    offset = int(request.args.get("offset", 0))
+    try:
+        limit = min(int(request.args.get("limit", 50)), 200)
+        offset = int(request.args.get("offset", 0))
+    except ValueError:
+        return jsonify({"error": "limit and offset must be integers"}), 400
 
     with get_cursor(commit=False) as cursor:
         cursor.execute(

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -370,3 +370,19 @@ def test_search_with_invalid_content_type_defaults_to_all(client):
         assert "results" in data
         # Invalid content_type should be excluded from filters
         assert "content_type" not in data.get("filters", {})
+
+
+@pytest.mark.unit
+def test_list_episodes_invalid_limit_returns_400(client):
+    """Test that invalid limit parameter returns 400 instead of raising ValueError."""
+    response = client.get("/api/transcripts/episodes?limit=abc")
+    assert response.status_code == 400
+    assert response.json == {"error": "limit and offset must be integers"}
+
+
+@pytest.mark.unit
+def test_list_episodes_invalid_offset_returns_400(client):
+    """Test that invalid offset parameter returns 400 instead of raising ValueError."""
+    response = client.get("/api/transcripts/episodes?offset=xyz")
+    assert response.status_code == 400
+    assert response.json == {"error": "limit and offset must be integers"}


### PR DESCRIPTION
## Summary
- Add try/except to handle invalid limit/offset parameters
- Return proper 400 error instead of uncaught ValueError
- Add unit tests for invalid parameter handling

## Test plan
- [x] Unit tests pass (198)
- [x] Rebased cleanly on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)