### PR TITLE
fix: Remove unreachable code in download retry loop

### DIFF
--- a/app/patreon/downloader.py
+++ b/app/patreon/downloader.py
@@ -86,8 +86,6 @@ class AudioDownloader:
                         error=str(e)
                     )
 
-        return DownloadResult(success=False, file_path=None, error="Max retries exceeded")
-
     def _download_with_resume(
         self,
         url: str,


### PR DESCRIPTION
## Summary
- Removes unreachable return statement after for loop in `download()` method
- The for loop always returns from inside (either on success or in the else block when max retries exhausted)

## Bead
Fixes cr-j9x0

## Test plan
- [x] Code inspection confirms the return statement was unreachable
- [ ] Run existing tests to verify no regression