### PR TITLE
fix: Remove unreachable code in download retry loop

### DIFF
--- a/app/patreon/downloader.py
+++ b/app/patreon/downloader.py
@@ -86,8 +86,6 @@ class AudioDownloader:
                         error=str(e)
                     )
 
-        return DownloadResult(success=False, file_path=None, error="Max retries exceeded")
-
     def _download_with_resume(
         self,
         url: str,


### PR DESCRIPTION
## Summary
- Removes unreachable return statement at line 89 in `app/patreon/downloader.py`
- The for loop always returns - either on success from `_download_with_resume()` or on the final attempt's exception handling

## Test plan
- [ ] Verify the download retry logic still works correctly
- [ ] Confirm no regressions in error handling

Fixes cr-j9x0