### PR TITLE
fix: Validate episode.id is not None before storage calls

### DIFF
--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -102,7 +102,16 @@ class EpisodePipeline:
 
         Returns:
             True if successful, False otherwise.
+
+        Raises:
+            ValueError: If episode.id is None (episode must be persisted first).
         """
+        if episode.id is None:
+            raise ValueError(
+                f"Cannot process episode '{episode.title}': episode.id is None. "
+                "Episode must be saved to database before processing."
+            )
+
         logger.info(f"Processing: {episode.title}")
 
         # Skip if already processed

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -87,6 +87,14 @@ def test_process_episode_success(pipeline):
 
 
 @pytest.mark.unit
+def test_process_episode_raises_when_id_is_none(pipeline):
+    episode = make_episode(id=None)
+    with pytest.raises(ValueError, match="episode.id is None"):
+        pipeline.process_episode(episode)
+    pipeline.downloader.download.assert_not_called()
+
+
+@pytest.mark.unit
 def test_process_episode_skips_already_processed(pipeline):
     episode = make_episode(processed=True)
     result = pipeline.process_episode(episode)


### PR DESCRIPTION
## Summary
- Add validation check in `process_episode()` to ensure `episode.id` is not None before calling storage methods
- Raises `ValueError` with descriptive message if an unpersisted episode is passed
- Prevents potential issues with NULL being passed to `delete_episode_transcript`, `store_transcript`, and `mark_processed`

## Test plan
- [x] Added unit test `test_process_episode_raises_when_id_is_none`
- [x] All 199 unit tests pass