### PR TITLE
feat: Configure CORS for production with CORS_ORIGINS env var

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -9,7 +9,7 @@ from app.config import Config
 def create_app():
     """Application factory."""
     app = Flask(__name__, static_folder="../ui/static", static_url_path="/static")
-    CORS(app)
+    CORS(app, origins=Config.get_cors_origins())
 
     app.register_blueprint(api)
     app.register_blueprint(transcript_api)

--- a/app/config.py
+++ b/app/config.py
@@ -6,3 +6,20 @@ class Config:
     DEBUG = os.environ.get("DEBUG", "false").lower() == "true"
     HOST = os.environ.get("HOST", "127.0.0.1")
     PORT = int(os.environ.get("PORT", 5000))
+    CORS_ORIGINS = os.environ.get("CORS_ORIGINS", "*")
+
+    @classmethod
+    def get_cors_origins(cls):
+        """Get CORS origins as a list or wildcard.
+
+        Returns '*' for wildcard (all origins allowed), or a list of
+        specific origins from comma-separated CORS_ORIGINS env var.
+
+        Examples:
+            CORS_ORIGINS='*' -> '*'
+            CORS_ORIGINS='https://app.railway.app' -> ['https://app.railway.app']
+            CORS_ORIGINS='https://app.railway.app,https://custom.com' -> ['https://app.railway.app', 'https://custom.com']
+        """
+        if cls.CORS_ORIGINS == "*":
+            return "*"
+        return [origin.strip() for origin in cls.CORS_ORIGINS.split(",") if origin.strip()]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,72 @@
+import pytest
+from unittest.mock import patch
+
+
+@pytest.mark.unit
+class TestCorsOrigins:
+    """Tests for CORS origins configuration."""
+
+    def test_cors_origins_default_is_wildcard(self):
+        """Test CORS_ORIGINS defaults to wildcard."""
+        with patch.dict("os.environ", {}, clear=True):
+            # Re-import to pick up new env
+            import importlib
+            import app.config
+            importlib.reload(app.config)
+            from app.config import Config
+
+            assert Config.CORS_ORIGINS == "*"
+
+    def test_cors_origins_from_env(self):
+        """Test CORS_ORIGINS is read from environment."""
+        with patch.dict("os.environ", {"CORS_ORIGINS": "https://example.com"}):
+            import importlib
+            import app.config
+            importlib.reload(app.config)
+            from app.config import Config
+
+            assert Config.CORS_ORIGINS == "https://example.com"
+
+    def test_get_cors_origins_wildcard(self):
+        """Test get_cors_origins returns '*' for wildcard."""
+        with patch.dict("os.environ", {"CORS_ORIGINS": "*"}):
+            import importlib
+            import app.config
+            importlib.reload(app.config)
+            from app.config import Config
+
+            result = Config.get_cors_origins()
+            assert result == "*"
+
+    def test_get_cors_origins_single_origin(self):
+        """Test get_cors_origins returns list for single origin."""
+        with patch.dict("os.environ", {"CORS_ORIGINS": "https://app.railway.app"}):
+            import importlib
+            import app.config
+            importlib.reload(app.config)
+            from app.config import Config
+
+            result = Config.get_cors_origins()
+            assert result == ["https://app.railway.app"]
+
+    def test_get_cors_origins_multiple_origins(self):
+        """Test get_cors_origins parses comma-separated origins."""
+        with patch.dict("os.environ", {"CORS_ORIGINS": "https://app.railway.app,https://custom.com"}):
+            import importlib
+            import app.config
+            importlib.reload(app.config)
+            from app.config import Config
+
+            result = Config.get_cors_origins()
+            assert result == ["https://app.railway.app", "https://custom.com"]
+
+    def test_get_cors_origins_trims_whitespace(self):
+        """Test get_cors_origins trims whitespace from origins."""
+        with patch.dict("os.environ", {"CORS_ORIGINS": "  https://app.railway.app , https://custom.com  "}):
+            import importlib
+            import app.config
+            importlib.reload(app.config)
+            from app.config import Config
+
+            result = Config.get_cors_origins()
+            assert result == ["https://app.railway.app", "https://custom.com"]


### PR DESCRIPTION
## Summary
- Add `CORS_ORIGINS` environment variable to configure allowed origins for cross-origin requests
- Default to `*` (all origins) for development compatibility
- Support comma-separated list of origins for production (e.g., `https://app.railway.app,https://custom.com`)
- Add `Config.get_cors_origins()` method to parse and return origins in flask-cors compatible format

## Test plan
- [x] Unit tests for `CORS_ORIGINS` default value
- [x] Unit tests for `get_cors_origins()` with wildcard
- [x] Unit tests for `get_cors_origins()` with single origin
- [x] Unit tests for `get_cors_origins()` with multiple comma-separated origins
- [x] Unit tests for whitespace trimming
- [x] All 6 new tests pass

## Usage
```bash
# Development (default - all origins allowed)
CORS_ORIGINS='*'

# Production - single origin
CORS_ORIGINS='https://app.railway.app'

# Production - multiple origins
CORS_ORIGINS='https://app.railway.app,https://custom.com'
```

Closes cr-kjhn7