### PR TITLE
fix: Add youtube_id field to Episode model (cr-s3y)

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -12,6 +12,7 @@ class Episode:
     published_at: Optional[datetime] = None
     duration_seconds: Optional[int] = None
     youtube_url: Optional[str] = None
+    youtube_id: Optional[str] = None
     is_free: bool = False
     processed: bool = False
     created_at: Optional[datetime] = None


### PR DESCRIPTION
## Summary
- Added `youtube_id` field to Episode dataclass model to match database schema
- Successfully processed 2 additional Chapo episodes:
  - Episode 960 "Data For Progress feat. Pod About List" - 15,538 words
  - Episode 959 "The Bopper's Lair" - 10,598 words
- 3 promotional posts skipped (no audio content)

## Context
The database schema includes a `youtube_id` column that was missing from the Episode model, causing `SELECT *` queries to fail when constructing Episode objects.

## Test plan
- [x] Pipeline ran successfully with `--no-sync --limit 5 --offset 5`
- [x] Episodes transcribed and stored in database