### PR TITLE
feat: Move YouTube embed below context in expanded search results

### DIFF
--- a/app/ui/static/styles.css
+++ b/app/ui/static/styles.css
@@ -555,9 +555,9 @@ h1 {
     overflow-y: auto;
 }
 
-/* Expanded YouTube embed in expanded view */
+/* Expanded YouTube embed in expanded view (appears below context) */
 .expanded-youtube-embed {
-    margin-bottom: 12px;
+    margin-top: 12px;
     border-radius: 8px;
     overflow: hidden;
     background: #000;


### PR DESCRIPTION
## Summary
- Reordered expanded search result view so transcript context appears first
- YouTube embed player now shows below the extended context text
- Updated CSS margin from bottom to top for proper spacing

## Test plan
- [x] Search for a term that appears in a free (YouTube) episode
- [x] Click expand on a result with the YT badge
- [x] Verify extended context text appears first
- [x] Verify YouTube embed appears below the context
- [x] Video should be queued to the correct timestamp

*Code reviewed by malcolm - logic verified correct*

Closes cr-u1hi3